### PR TITLE
Drop redundant configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Ansible role to configure apt
   * [apt_enable_universe](#apt_enable_universe)
   * [apt_force_update](#apt_force_update)
   * [apt_periodic_config](#apt_periodic_config)
+  * [apt_redundant_configs](#apt_redundant_configs)
   * [apt_unattended_upgrade_allowed_origins](#apt_unattended_upgrade_allowed_origins)
   * [apt_unattended_upgrade_dev_release](#apt_unattended_upgrade_dev_release)
   * [apt_unattended_upgrade_download_limit](#apt_unattended_upgrade_download_limit)
@@ -86,6 +87,17 @@ apt_periodic_config:
     value: 1
   - name: Unattended-Upgrade
     value: 0
+```
+
+### apt_redundant_configs
+
+List of redundant configs that gets deleted
+
+#### Default value
+
+```YAML
+apt_redundant_configs:
+  - 20auto-upgrades
 ```
 
 ### apt_unattended_upgrade_allowed_origins
@@ -211,7 +223,7 @@ apt_unattended_upgrade_syslog_facility: daemon
 
 ## Dependencies
 
-- None
+* None
 
 ## License
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,10 @@ apt_enable_backports: True
 # @var apt_force_update:description: Force apt cache update
 apt_force_update: False
 
+# @var apt_redundant_configs:description: List of redundant configs that gets deleted
+apt_redundant_configs:
+  - 20auto-upgrades
+
 # @var apt_periodic_config:description: Set apt options for daily tasks
 apt_periodic_config:
   - name: Update-Package-Lists

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,6 +22,14 @@
   tags:
     - apt
 
+- name: Drop redundant configs
+  loop: "{{ apt_redundant_configs }}"
+  file:
+    path: "/etc/apt/apt.conf.d/{{ item }}"
+    state: absent
+  tags:
+    - apt
+
 - name: Update apt cache
   when: apt_force_update or apt_sources.changed
   register: result


### PR DESCRIPTION
Some config files could be redundant, as an example 20auto-upgrades gets
always created which overrides the unattended upgrades defined within
10periodic, with that change this file simply gets removed to being able
to properly disable or enable unattended upgrades. Another potention
candidate could be 99apt-dater-host_periodic if apt-dater is installed.